### PR TITLE
Change name to support shiden

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ window.addEventListener("message", ({ data, source }) => {
 });
 
 injectExtension(enable, {
-  name: "novawallet-extension",
+  name: "polkadot-js",
   version: "1.0",
 });
 


### PR DESCRIPTION
Shiden DApp detects extensions by 'polkadot-js' name. The name of the nova extension is temporarily changed as a workaround?