### PR TITLE
add isNovaWallet flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ class WalletExtension {
     window.walletExtension = {
       onAppResponse: this.onAppResponse.bind(this),
       onAppSubscription: this.onAppSubscription.bind(this),
+      isNovaWallet: true
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ declare global {
     walletExtension: {
       onAppResponse: (msgType: string, response: any, error: Error) => void
       onAppSubscription: (requestId: string, subscriptionString: string) => void
+      isNovaWallet: bool
     },
     injectedWeb3: {
       [key: string]: {}


### PR DESCRIPTION
The main reason for the flag is to give option for DApps to provide a custom logic depending on extension.

Usage from DApp perspective: 
```
if (window.walletExtension.isNovaWallet) {
  // do something for Nova Wallet
}
```

**Checked with inspector**

<img width="512" alt="inspector" src="https://user-images.githubusercontent.com/570634/169851488-911db4d0-6fb4-4e4d-a01e-28d477a8cb48.png">

